### PR TITLE
fix: change Welcome! text color from black to red

### DIFF
--- a/riptus.net/wp-content/themes/riptus/css/main_b34e095e.css
+++ b/riptus.net/wp-content/themes/riptus/css/main_b34e095e.css
@@ -547,7 +547,7 @@
 .riptus-web-text101 {
   top: 109px;
   left: -40px;
-  color: rgb(0, 0, 0);
+  color: rgb(255, 0, 0);
   right: 0px;
   width: 882px;
   height: 223px;
@@ -1946,7 +1946,7 @@ p.sec-line-text {
   .riptus-web-text101 {
     top: 120px !important;
     left: -10px;
-    color: rgb(0, 0, 0);
+    color: rgb(255, 0, 0);
     right: 0px;
     width: 882px;
     height: 223px;


### PR DESCRIPTION
Changes the "Welcome!" text color from black to red as requested in issue #14.

**Changes made:**
- Updated `.riptus-web-text101` class in `main_b34e095e.css`
- Changed color from `rgb(0, 0, 0)` to `rgb(255, 0, 0)`
- Applied to both desktop and tablet responsive views

Fixes #14

🤖 Generated with [Claude Code](https://claude.ai/code)