### PR TITLE
Use GH_TOKEN PAT instead of GITHUB_TOKEN for org repo access

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GH_TOKEN }}
           direct_prompt: |
             Issue title: ${{ github.event.issue.title }}
             Issue body: ${{ github.event.issue.body }}


### PR DESCRIPTION
Adding credentials