### PR TITLE
fix: change Welcome text color to black and update copyright to 2026

### DIFF
--- a/riptus.net/index.html
+++ b/riptus.net/index.html
@@ -283,7 +283,7 @@ gtag("config", "GT-T5RLNBWV");
         -->
 </div>
 <div class="riptus-web-footer">
-<span class="riptus-web-text085"><span>© 2025</span></span>
+<span class="riptus-web-text085"><span>© 2026</span></span>
 <img alt="spanseparator5051" class="riptus-web-spanseparator" src="wp-content/themes/riptus/public/spanseparator5051-3vzo-200h.png"/>
 <span class="riptus-web-text087"><span>Riptus</span></span>
 </div>

--- a/riptus.net/wp-content/themes/riptus/css/main_b34e095e.css
+++ b/riptus.net/wp-content/themes/riptus/css/main_b34e095e.css
@@ -547,7 +547,7 @@
 .riptus-web-text101 {
   top: 109px;
   left: -40px;
-  color: rgb(255, 0, 0);
+  color: rgb(0, 0, 0) !important;
   right: 0px;
   width: 882px;
   height: 223px;
@@ -1946,7 +1946,7 @@ p.sec-line-text {
   .riptus-web-text101 {
     top: 120px !important;
     left: -10px;
-    color: rgb(255, 0, 0);
+    color: rgb(0, 0, 0) !important;
     right: 0px;
     width: 882px;
     height: 223px;


### PR DESCRIPTION
- Changed "Welcome!" text color from red to black using !important
- Updated copyright from "© 2025" to "© 2026" in footer
- Applied changes to both desktop and mobile responsive CSS rules

Fixes #25

Generated with [Claude Code](https://claude.ai/code)