### PR TITLE
feat: update copyright years to 2026

### DIFF
--- a/riptus.net/2740616d/index.html
+++ b/riptus.net/2740616d/index.html
@@ -283,7 +283,7 @@ gtag("config", "GT-T5RLNBWV");
         -->
 </div>
 <div class="riptus-web-footer">
-<span class="riptus-web-text085"><span>© 2025</span></span>
+<span class="riptus-web-text085"><span>© 2026</span></span>
 <img alt="spanseparator5051" class="riptus-web-spanseparator" src="/wp-content/themes/riptus/public/spanseparator5051-3vzo-200h.png"/>
 <span class="riptus-web-text087"><span>Riptus</span></span>
 </div>

--- a/riptus.net/389b2a73/index.html
+++ b/riptus.net/389b2a73/index.html
@@ -283,7 +283,7 @@ gtag("config", "GT-T5RLNBWV");
         -->
 </div>
 <div class="riptus-web-footer">
-<span class="riptus-web-text085"><span>© 2025</span></span>
+<span class="riptus-web-text085"><span>© 2026</span></span>
 <img alt="spanseparator5051" class="riptus-web-spanseparator" src="/wp-content/themes/riptus/public/spanseparator5051-3vzo-200h.png"/>
 <span class="riptus-web-text087"><span>Riptus</span></span>
 </div>

--- a/riptus.net/66be75e4/index.html
+++ b/riptus.net/66be75e4/index.html
@@ -283,7 +283,7 @@ gtag("config", "GT-T5RLNBWV");
         -->
 </div>
 <div class="riptus-web-footer">
-<span class="riptus-web-text085"><span>© 2025</span></span>
+<span class="riptus-web-text085"><span>© 2026</span></span>
 <img alt="spanseparator5051" class="riptus-web-spanseparator" src="/wp-content/themes/riptus/public/spanseparator5051-3vzo-200h.png"/>
 <span class="riptus-web-text087"><span>Riptus</span></span>
 </div>

--- a/riptus.net/6ca8cc79/index.html
+++ b/riptus.net/6ca8cc79/index.html
@@ -283,7 +283,7 @@ gtag("config", "GT-T5RLNBWV");
         -->
 </div>
 <div class="riptus-web-footer">
-<span class="riptus-web-text085"><span>© 2025</span></span>
+<span class="riptus-web-text085"><span>© 2026</span></span>
 <img alt="spanseparator5051" class="riptus-web-spanseparator" src="/wp-content/themes/riptus/public/spanseparator5051-3vzo-200h.png"/>
 <span class="riptus-web-text087"><span>Riptus</span></span>
 </div>

--- a/riptus.net/ac47eacb/index.html
+++ b/riptus.net/ac47eacb/index.html
@@ -283,7 +283,7 @@ gtag("config", "GT-T5RLNBWV");
         -->
 </div>
 <div class="riptus-web-footer">
-<span class="riptus-web-text085"><span>© 2025</span></span>
+<span class="riptus-web-text085"><span>© 2026</span></span>
 <img alt="spanseparator5051" class="riptus-web-spanseparator" src="/wp-content/themes/riptus/public/spanseparator5051-3vzo-200h.png"/>
 <span class="riptus-web-text087"><span>Riptus</span></span>
 </div>

--- a/riptus.net/all-blogs/index.html
+++ b/riptus.net/all-blogs/index.html
@@ -288,7 +288,7 @@ gtag("config", "GT-T5RLNBWV");
         -->
 </div>
 <div class="riptus-web-footer">
-<span class="riptus-web-text085"><span>© 2025</span></span>
+<span class="riptus-web-text085"><span>© 2026</span></span>
 <img alt="spanseparator5051" class="riptus-web-spanseparator" src="/wp-content/themes/riptus/public/spanseparator5051-3vzo-200h.png"/>
 <span class="riptus-web-text087"><span>Riptus</span></span>
 </div>

--- a/riptus.net/blog/1/index.html
+++ b/riptus.net/blog/1/index.html
@@ -292,7 +292,7 @@ gtag("config", "GT-T5RLNBWV");
         -->
 </div>
 <div class="riptus-web-footer">
-<span class="riptus-web-text085"><span>© 2025</span></span>
+<span class="riptus-web-text085"><span>© 2026</span></span>
 <img alt="spanseparator5051" class="riptus-web-spanseparator" src="/wp-content/themes/riptus/public/spanseparator5051-3vzo-200h.png"/>
 <span class="riptus-web-text087"><span>Riptus</span></span>
 </div>

--- a/riptus.net/blog/index.html
+++ b/riptus.net/blog/index.html
@@ -284,7 +284,7 @@ gtag("config", "GT-T5RLNBWV");
         -->
 </div>
 <div class="riptus-web-footer">
-<span class="riptus-web-text085"><span>© 2025</span></span>
+<span class="riptus-web-text085"><span>© 2026</span></span>
 <img alt="spanseparator5051" class="riptus-web-spanseparator" src="/wp-content/themes/riptus/public/spanseparator5051-3vzo-200h.png"/>
 <span class="riptus-web-text087"><span>Riptus</span></span>
 </div>

--- a/riptus.net/blog/seg-569d57a4/index.html
+++ b/riptus.net/blog/seg-569d57a4/index.html
@@ -289,7 +289,7 @@ gtag("config", "GT-T5RLNBWV");
         -->
 </div>
 <div class="riptus-web-footer">
-<span class="riptus-web-text085"><span>© 2025</span></span>
+<span class="riptus-web-text085"><span>© 2026</span></span>
 <img alt="spanseparator5051" class="riptus-web-spanseparator" src="/wp-content/themes/riptus/public/spanseparator5051-3vzo-200h.png"/>
 <span class="riptus-web-text087"><span>Riptus</span></span>
 </div>

--- a/riptus.net/blog/seg-8307db4d/index.html
+++ b/riptus.net/blog/seg-8307db4d/index.html
@@ -289,7 +289,7 @@ gtag("config", "GT-T5RLNBWV");
         -->
 </div>
 <div class="riptus-web-footer">
-<span class="riptus-web-text085"><span>© 2025</span></span>
+<span class="riptus-web-text085"><span>© 2026</span></span>
 <img alt="spanseparator5051" class="riptus-web-spanseparator" src="/wp-content/themes/riptus/public/spanseparator5051-3vzo-200h.png"/>
 <span class="riptus-web-text087"><span>Riptus</span></span>
 </div>

--- a/riptus.net/blog/unibase-asakusa/index.html
+++ b/riptus.net/blog/unibase-asakusa/index.html
@@ -289,7 +289,7 @@ gtag("config", "GT-T5RLNBWV");
         -->
 </div>
 <div class="riptus-web-footer">
-<span class="riptus-web-text085"><span>© 2025</span></span>
+<span class="riptus-web-text085"><span>© 2026</span></span>
 <img alt="spanseparator5051" class="riptus-web-spanseparator" src="/wp-content/themes/riptus/public/spanseparator5051-3vzo-200h.png"/>
 <span class="riptus-web-text087"><span>Riptus</span></span>
 </div>

--- a/riptus.net/cb29b525/index.html
+++ b/riptus.net/cb29b525/index.html
@@ -283,7 +283,7 @@ gtag("config", "GT-T5RLNBWV");
         -->
 </div>
 <div class="riptus-web-footer">
-<span class="riptus-web-text085"><span>© 2025</span></span>
+<span class="riptus-web-text085"><span>© 2026</span></span>
 <img alt="spanseparator5051" class="riptus-web-spanseparator" src="/wp-content/themes/riptus/public/spanseparator5051-3vzo-200h.png"/>
 <span class="riptus-web-text087"><span>Riptus</span></span>
 </div>

--- a/riptus.net/privacy-policy/index.html
+++ b/riptus.net/privacy-policy/index.html
@@ -291,7 +291,7 @@ gtag("config", "GT-T5RLNBWV");
         -->
 </div>
 <div class="riptus-web-footer">
-<span class="riptus-web-text085"><span>© 2025</span></span>
+<span class="riptus-web-text085"><span>© 2026</span></span>
 <img alt="spanseparator5051" class="riptus-web-spanseparator" src="/wp-content/themes/riptus/public/spanseparator5051-3vzo-200h.png"/>
 <span class="riptus-web-text087"><span>Riptus</span></span>
 </div>

--- a/riptus.net/terms-and-condition/index.html
+++ b/riptus.net/terms-and-condition/index.html
@@ -291,7 +291,7 @@ gtag("config", "GT-T5RLNBWV");
         -->
 </div>
 <div class="riptus-web-footer">
-<span class="riptus-web-text085"><span>© 2025</span></span>
+<span class="riptus-web-text085"><span>© 2026</span></span>
 <img alt="spanseparator5051" class="riptus-web-spanseparator" src="/wp-content/themes/riptus/public/spanseparator5051-3vzo-200h.png"/>
 <span class="riptus-web-text087"><span>Riptus</span></span>
 </div>


### PR DESCRIPTION
Updates all copyright years from 2025 to 2026 across all website pages.

## Changes
- Updated copyright notices in 14 HTML files
- Main page was already at 2026
- All pages now consistently show "© 2026 Riptus"

Closes #27

🤖 Generated with [Claude Code](https://claude.ai/code)